### PR TITLE
Fix flipped arguments

### DIFF
--- a/Keras Adversarial Autoencoder MNIST.ipynb
+++ b/Keras Adversarial Autoencoder MNIST.ipynb
@@ -261,7 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def sample_prior(latent_dim, batch_size):\n",
+    "def sample_prior(batch_size, latent_dim):\n",
     "    return np.random.normal(size=(batch_size, latent_dim))"
    ]
   },
@@ -862,7 +862,7 @@
     "    latent_fake = encoder.predict(imgs)\n",
     "    \n",
     "    # Here we generate the \"TRUE\" samples\n",
-    "    latent_real = sample_prior(latent_dim, batch_size)\n",
+    "    latent_real = sample_prior(batch_size, latent_dim)\n",
     "                      \n",
     "    # Train the discriminator\n",
     "    d_loss_real = discriminator.train_on_batch(latent_real, valid)\n",


### PR DESCRIPTION
This fixes #1.

Note: 
- There's still an (unrelated) error when running the file in colab `No such file or directory: 'images/mnist_0.png`. It can trivially be fixed by creating the folder `images`. I assume this is intentional.